### PR TITLE
Update cache_expires

### DIFF
--- a/lib/pendragon/padrino/route.rb
+++ b/lib/pendragon/padrino/route.rb
@@ -3,7 +3,7 @@ require 'pendragon/route'
 module Pendragon
   module Padrino
     class Route < ::Pendragon::Route
-      attr_accessor :action, :cache, :cache_key, :cache_expires_in, :parent,
+      attr_accessor :action, :cache, :cache_key, :cache_expires, :parent,
                     :use_layout, :controller, :user_agent, :path_for_generation
 
       def before_filters(&block)


### PR DESCRIPTION
Hi @namusyaka, is there any particular reason why `cache_expires_in` isn't `cache_expires`? Padrino is using the latter. See [here](https://github.com/padrino/padrino-framework/blob/master/padrino-core/lib/padrino-core/ext/http_router.rb#L48) and [here](https://github.com/padrino/padrino-framework/blob/master/padrino-cache/lib/padrino-cache/helpers/page.rb#L63). Thanks :)
